### PR TITLE
Fix for ember beta / canary

### DIFF
--- a/addon/components/wrap-urls/index.hbs
+++ b/addon/components/wrap-urls/index.hbs
@@ -1,7 +1,9 @@
-{{#each this.parts as |part|}}
-  {{#if part.string}}
-    {{~""~}}<this.component @url={{part}} />{{~""~}}
-  {{else}}
-    {{~""~}}{{part}}{{~""~}}
-  {{/if}}
-{{/each}}
+{{#let (component this.component) as |Component|}}
+  {{#each this.parts as |part|}}
+    {{#if part.string}}
+      {{~""~}}<Component @url={{part}} />{{~""~}}
+    {{else}}
+      {{~""~}}{{part}}{{~""~}}
+    {{/if}}
+  {{/each}}
+{{/let}}


### PR DESCRIPTION
Makes sure the component used to render URLs is an actual component, and not just the name of a component.